### PR TITLE
Flattening objects properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,16 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.1.1] - 2015-05-06
+### Added 
+* Flattening all object based properties
+* ensuring that each feature contains each field  
+
 ## [0.1.0] - 2015-04-21
 ### Changed
 * This project now uses `standard` as its code formatting
 * Keeping a legit changelog
 * Added tape testing with sinon stubs in the controller tests
 
+[0.1.1]: https://github.com/Esri/koop/releases/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/Esri/koop/releases/tag/v0.1.0

--- a/controller/index.js
+++ b/controller/index.js
@@ -136,6 +136,7 @@ var Controller = function (Socrata, BaseController) {
         res.send(err, 500)
       } else {
         // Get the item
+        req.query.limit = 10000000;
         Socrata.getResource(data.host, req.params.id, req.params.item, req.query, function (error, geojson) {
           if (error) {
             res.send(error, 500)

--- a/controller/index.js
+++ b/controller/index.js
@@ -136,7 +136,7 @@ var Controller = function (Socrata, BaseController) {
         res.send(err, 500)
       } else {
         // Get the item
-        req.query.limit = 10000000;
+        req.query.limit = 10000000
         Socrata.getResource(data.host, req.params.id, req.params.item, req.query, function (error, geojson) {
           if (error) {
             res.send(error, 500)

--- a/models/Socrata.js
+++ b/models/Socrata.js
@@ -39,7 +39,6 @@ var Socrata = function (koop) {
   }
 
   socrata.socrata_path = '/resource/'
-
   // got the service and get the item
   socrata.getResource = function (host, hostId, id, options, callback) {
     var type = 'Socrata',
@@ -61,7 +60,7 @@ var Socrata = function (koop) {
     koop.Cache.get(type, key, options, function (err, entry) {
       if (err) {
         var url = host + socrata.socrata_path + urlid + '.json?$order=:id&$limit=' + limit
-        request.get(url, function (err, data, response) {
+        socrata.request(url, function (err, data, response) {
           if (err) {
             callback(err, null)
           } else {
@@ -85,7 +84,7 @@ var Socrata = function (koop) {
               }
 
               // parse first page to geoJSON and insert
-              socrata.toGeojson(JSON.parse(data.body), locationField, function (err, geojson) {
+              socrata.toGeojson(JSON.parse(data.body), locationField, fields, function (err, geojson) {
                 if (err) {
                   return callback(err)
                 }
@@ -170,7 +169,6 @@ var Socrata = function (koop) {
                 })
               })
             } catch (e) {
-              console.log('Error?', e)
               koop.log.error('Unable to parse response %s', url)
               callback(e, null)
             }
@@ -182,15 +180,31 @@ var Socrata = function (koop) {
     })
   }
 
-  socrata.toGeojson = function (json, locationField, callback) {
+  socrata.toGeojson = function (json, locationField, fields, callback) {
     if (!json || !json.length) {
       callback('Error converting data to geojson', null)
     } else {
       var geojson = { type: 'FeatureCollection', features: [] }
-      var geojsonFeature
+      var geojsonFeature,
+        newFields = []
       json.forEach(function (feature, i) {
         var lat, lon
         geojsonFeature = { type: 'Feature', geometry: {}, id: i + 1 }
+
+        // make sure each feature has each property and flatten objects
+        fields.forEach(function (f) {
+          if (f.substring(0, 1) !== ':') {
+            if (typeof feature[f] === 'object') {
+              for (var v in feature[f]) {
+                var newAttr = f + '_' + v
+                feature[newAttr] = feature[f][v]
+                newFields.push(newAttr)
+              }
+              delete feature[f]
+            }
+          }
+        })
+
         if (feature && locationField) {
           lon = parseFloat(feature[locationField].longitude)
           lat = parseFloat(feature[locationField].latitude)
@@ -224,6 +238,16 @@ var Socrata = function (koop) {
           geojson.features.push(geojsonFeature)
         }
       })
+      // 2nd loop over the data to ensure all new fields are present
+      if (newFields && newFields.length) {
+        geojson.features.forEach(function (feature) {
+          newFields.forEach(function (field) {
+            if (!feature.properties[field]) {
+              feature.properties[field] = null
+            }
+          })
+        })
+      }
       callback(null, geojson)
     }
   }
@@ -248,7 +272,7 @@ var Socrata = function (koop) {
               locationField = fields[i]
             }
           })
-          socrata.toGeojson(JSON.parse(data.body), locationField, function (error, geojson) {
+          socrata.toGeojson(JSON.parse(data.body), locationField, fields, function (error, geojson) {
             geojson.updated_at = new Date(data.headers['last-modified']).getTime()
             geojson.name = data.name || key
             geojson.host = data.host

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "Chris Helm",
   "license": "BSD-2-Clause",
   "devDependencies": {
-    "koop": "~1.0.0",
+    "koop": "*",
     "sinon": "^1.14.1",
     "standard": "^3.3.0",
     "supertest": "~0.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koop-socrata",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A socrata wrapper for koop ",
   "main": "index.js",
   "scripts": {
@@ -15,9 +15,9 @@
   "author": "Chris Helm",
   "license": "BSD-2-Clause",
   "devDependencies": {
-    "koop": "*",
+    "koop": "~1.0.0",
     "sinon": "^1.14.1",
-    "standard": "*",
+    "standard": "^3.3.0",
     "supertest": "~0.11.0",
     "tap-spec": "^2.2.2",
     "tape": "^3.5.0"

--- a/test/model.js
+++ b/test/model.js
@@ -22,15 +22,36 @@ test('adding a socrata instance', function (t) {
 })
 
 test('parsing geojson', function (t) {
-  t.plan(2)
+  t.plan(5)
 
-  socrata.toGeojson([], 'location', function (err, geojson) {
+  socrata.toGeojson([], 'location', [], function (err, geojson) {
     t.deepEqual(err, 'Error converting data to geojson')
   })
 
-  socrata.toGeojson(data, 'location', function (err, geojson) {
+  socrata.toGeojson(data, 'location', [], function (err, geojson) {
     if (err) throw err
     t.deepEqual(geojson.features.length, 1000)
+  })
+
+  var features = [{
+    obj: {
+      prop: true
+    },
+    location: {
+      latitude: 0,
+      longitude: 0
+    }
+  },{
+    location: {
+      latitude: 0,
+      longitude: 0
+    }
+  }]
+  socrata.toGeojson(features, 'location', ['obj'], function (err, geojson) {
+    if (err) throw err
+    t.deepEqual(geojson.features[0].properties, {obj_prop: true})
+    t.deepEqual(geojson.features[1].properties, {obj_prop: null})
+    t.deepEqual(geojson.features.length, 2)
   })
 
 })
@@ -55,7 +76,7 @@ test('stub the request method', function (t) {
     }
   }
 
-  sinon.stub(socrata, 'toGeojson', function (features, locationField, callback) {
+  sinon.stub(socrata, 'toGeojson', function (features, locationField, fields, callback) {
     callback(null, { features: [feature] })
   })
   sinon.stub(koop.Cache, 'insert', function (type, key, geojson, layer, callback) {

--- a/test/model.js
+++ b/test/model.js
@@ -41,7 +41,7 @@ test('parsing geojson', function (t) {
       latitude: 0,
       longitude: 0
     }
-  },{
+  }, {
     location: {
       latitude: 0,
       longitude: 0


### PR DESCRIPTION
This PR adds flattening of object properties so feature services don't choke on nested object properties. Also ensures that each feature in the cached geojson matches the schema of every feature (contains all the same properties).

Includes a test for this too.