### PR TITLE
adding result offsets for query limit overriding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.2.2] - 2015-05-28
+### Changed
+* Respecting resultOffset, resultOffsetCount, and limit/offset when querying featureservices
+
 ## [0.2.1] - 2015-05-08
 ### Added
 * Allows provider to make requests using an app token, if available
@@ -26,6 +30,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * Keeping a legit changelog
 * Added tape testing with sinon stubs in the controller tests
 
+[0.2.2]: https://github.com/Esri/koop/releases/compare/v0.2.1...v0.2.2
+[0.2.1]: https://github.com/Esri/koop/releases/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/Esri/koop/releases/compare/v0.1.2...v0.2.0
 [0.1.2]: https://github.com/Esri/koop/releases/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/Esri/koop/releases/compare/v0.1.0...v0.1.1

--- a/controller/index.js
+++ b/controller/index.js
@@ -148,7 +148,8 @@ var Controller = function (Socrata, BaseController) {
         res.send(err, 500)
       } else {
         // Get the item
-        req.query.limit = 10000000
+        req.query.limit = req.query.limit || req.query.resultRecordCount || 1000000000
+        req.query.offset = req.query.resultOffset || null
         Socrata.getResource(data.host, req.params.id, req.params.item, req.query, function (error, geojson) {
           if (error) {
             res.send(error, 500)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koop-socrata",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "A socrata wrapper for koop ",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
we need to pass the resultOffset to the DB query as limit/offsets so the pagination via the featureservice needs to happen in each provider. Kind of annoying. 