### PR TITLE
feature service records are counted in the db

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.3.1] - 2015-06-08
+### Changed
+* Feature service counts occur without fetching features from the cache
+
 ## [0.3.0] - 2015-06-07
 ### Added
 * 502 response contains error messages

--- a/controller/index.js
+++ b/controller/index.js
@@ -140,11 +140,10 @@ var Controller = function (Socrata, BaseController) {
       })
     }
   }
-
+  // shared dispath for feature service responses
   controller.featureserver = function (req, res) {
     var callback = req.query.callback
     delete req.query.callback
-
     for (var k in req.body) {
       req.query[k] = req.body[k]
     }
@@ -152,21 +151,57 @@ var Controller = function (Socrata, BaseController) {
       if (err) {
         res.status(500).send(err)
       } else {
-        // Get the item
-        req.query.limit = req.query.limit || req.query.resultRecordCount || 1000000000
-        req.query.offset = req.query.resultOffset || null
-        Socrata.getResource(data.host, req.params.id, req.params.item, req.query, function (error, geojson) {
-          if (error) {
-            res.status(500).send(error)
-          } else if (geojson[0] && geojson[0].status === 'processing') {
-            res.status(202).send(geojson)
+        var host = data.host
+        // if this is a count request then go straight to the db
+        if (req.query.returnCountOnly) {
+          controller.featureserviceCount(req, res, host)
+        } else {
+          // else send this down for further processing
+          controller.featureservice(req, res, host, callback)
+        }
+      }
+    })
+  }
+
+  controller.featureserviceCount = function (req, res, host) {
+    // first check if the dataset is new, in the cache, or processing
+    // ask for a single feature becasue we just want to know if the data is there
+    req.query.limit = 1
+    Socrata.getResource(host, req.params.id, req.params.item, req.query, function (err, geojson) {
+      if (err) {
+        res.status(500).send(err)
+      } else if (geojson[0] && geojson[0].status === 'processing') {
+        res.status(202).json(geojson)
+      } else {
+        // it's not processing so send for the count
+        Socrata.getCount(['Socrata', req.params.item, (req.query.layer || 0)].join(':'), req.query, function (err, count) {
+          if (err) {
+            console.log('Could not get feature count', req.params.item)
+            res.status(500).send(err)
           } else {
-            // pass to the shared logic for FeatureService routing
-            delete req.query.geometry
-            delete req.query.where
-            controller.processFeatureServer(req, res, err, geojson, callback)
+            var response = {count: count}
+            res.status(200).json(response)
           }
         })
+      }
+    })
+  }
+
+  controller.featureservice = function (req, res, host, callback) {
+    var err
+    req.query.limit = req.query.limit || req.query.resultRecordCount || 1000000000
+    req.query.offset = req.query.resultOffset || null
+    // Get the item
+    Socrata.getResource(host, req.params.id, req.params.item, req.query, function (error, geojson) {
+      if (error) {
+        res.status(500).send(error)
+      } else if (geojson[0] && geojson[0].status === 'processing') {
+        res.status(202).json(geojson)
+      } else {
+        // pass to the shared logic for FeatureService routing
+        delete req.query.geometry
+        delete req.query.where
+        controller.processFeatureServer(req, res, err, geojson, callback)
       }
     })
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koop-socrata",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A socrata wrapper for koop ",
   "main": "index.js",
   "scripts": {

--- a/test/controller.js
+++ b/test/controller.js
@@ -33,6 +33,9 @@ test('setup', function (t) {
   sinon.stub(model, 'getResource', function (host, id, item, options, callback) {
     callback(null, {})
   })
+  sinon.stub(model, 'getCount', function (key, options, callback) {
+    callback(null, 0)
+  })
   sinon.stub(controller, 'processFeatureServer', function (req, res, err, geojson, callback) {
     res.send({})
   })
@@ -93,11 +96,22 @@ test('getting a featureservice calls the model find, getResource methods and con
     })
 })
 
+test('getting a feature service count calls model get resource and get count', function (t) {
+  request(koop)
+  .get('/socrata/seattle/fake/FeatureServer/0/query?where=1=1&returnCountOnly=true')
+  .end(function () {
+    t.equals(model.getResource.called, true)
+    t.equals(model.getCount.called, true)
+    t.end()
+  })
+})
+
 test('teardown', function (t) {
   model.register.restore()
   model.find.restore()
   model.dropItem.restore()
   model.getResource.restore()
+  model.getCount.restore()
   controller.processFeatureServer.restore()
   t.end()
 })


### PR DESCRIPTION
part of #31 
```bash
ab -n 5 http://koop.dev:1337/socrata/sea/3k2p-39jp/FeatureServer/0/query\?where\=1\=1\&returnCountOnly\=true
This is ApacheBench, Version 2.3 <$Revision: 1604373 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking koop.dev (be patient).....done


Server Software:
Server Hostname:        koop.dev
Server Port:            1337

Document Path:          /socrata/sea/3k2p-39jp/FeatureServer/0/query?where=1=1&returnCountOnly=true
Document Length:        17 bytes

Concurrency Level:      1
Time taken for tests:   4.132 seconds
Complete requests:      5
Failed requests:        0
Total transferred:      1070 bytes
HTML transferred:       85 bytes
Requests per second:    1.21 [#/sec] (mean)
Time per request:       826.379 [ms] (mean)
Time per request:       826.379 [ms] (mean, across all concurrent requests)
Transfer rate:          0.25 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.0      0       0
Processing:   814  826   8.6    827     838
Waiting:      814  826   8.6    826     838
Total:        814  826   8.6    827     838

Percentage of the requests served within a certain time (ms)
  50%    826
  66%    827
  75%    827
  80%    838
  90%    838
  95%    838
  98%    838
  99%    838
 100%    838 (longest request)
```