### PR TITLE
ensure that logfiles created by running tests have valid filenames and are ignored by git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 npm-debug.log
+test*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 * bumped version of leaflet/esri leaflet used by preview
 * cleaned up views/demo.ejs
+* ensured log files created by passing tests have valid filenames and are ignored by git
 
 ## [1.0.1] - 2015-07-29
 ### Fixed

--- a/test/model.js
+++ b/test/model.js
@@ -39,7 +39,8 @@ requests.get('/api/geospatial/zip?method=export&format=Original').times(2).reply
 // use Koop's local cache as a db for tests
 koop.Cache = new koop.DataCache(koop)
 koop.Cache.db = koop.LocalDB
-koop.log = new koop.Logger({logfile: './'})
+
+koop.log = new koop.Logger({logfile: 'test'})
 
 var socrata = require('../models/Socrata.js')(koop)
 


### PR DESCRIPTION
its not exactly elegant, but this change resolves #53 and ensures that log files created by a successful run of tests

1. reside in the test folder
2. have valid filenames (ie: `test.YYYY-MM-DD` and `test.error.YYYY-MM-DD`)
3. are ignored by git

if its worthwhile for me to submit a PR to [koop](https://github.com/koopjs/koop/blob/master/lib/Logger.js#L14) itself w/ the change @ngoldman and i discussed via IRC, (or if i misunderstood the suggestion) please let me know.

```js
// in koop/lib/Logger.js
var logpath = config.logfile.split('/').slice(-1, 1).join('/')

// becomes
var path = require('path')
...
var logpath = path.join(config.logfile)
```
right now, the only benefit i can see is making the logger more windows friendly

ref: winstonjs/winston#589