### PR TITLE
Fix to support returning all fields and numbers

### DIFF
--- a/models/Socrata.js
+++ b/models/Socrata.js
@@ -195,6 +195,7 @@ var Socrata = function (koop) {
                 meta.location_field = location_field || info.location_field
                 meta.updated_at = info.updated_at
                 meta.fields = info.fields
+                meta.field_types = info.field_types || []
                 meta.blobFilename = info.blobFilename
               }
             }
@@ -273,8 +274,10 @@ var Socrata = function (koop) {
         meta.updated_at = new Date(res.headers['last-modified'])
         meta.name = response.name
         meta.fields = []
+        meta.field_types = []
         response.columns.forEach(function (col) {
           meta.fields.push(col.fieldName)
+          meta.field_types.push(col.dataTypeName)
           if (col.dataTypeName === 'location') {
             meta.location_field = col.fieldName
           }
@@ -341,7 +344,7 @@ var Socrata = function (koop) {
     dataStream
       .pipe(JSONStream.parse('*'))
       .pipe(es.map(function (data, cb) {
-        socrata.toGeojson([data], meta.location_field, meta.fields, function (err, converted) {
+        socrata.toGeojson([data], meta, function (err, converted) {
           if (err) {
             cb(err)
           }
@@ -358,7 +361,7 @@ var Socrata = function (koop) {
   }
 
   socrata.ingestResource = function (host, id, meta, firstRow, pageQueue, callback) {
-    socrata.toGeojson(firstRow, meta.location_field, meta.fields, function (err, geojson) {
+    socrata.toGeojson(firstRow, meta, function (err, geojson) {
       if (err) {
         callback('Failed to parse the first row at: ' + host + id + '. ' + err)
       // update status as failed
@@ -402,13 +405,16 @@ var Socrata = function (koop) {
     })
   }
 
-  socrata.toGeojson = function (json, locationField, fields, callback) {
+  socrata.toGeojson = function (json, meta, callback) {
     if (!json || !json.length) {
       callback('Error converting data to GeoJSON: JSON not returned from Socrata or blank JSON returned', null)
     } else {
       var geojson = { type: 'FeatureCollection', features: [] }
       var geojsonFeature
       var newFields = []
+      var locationField = meta.location_field
+      var fields = meta.fields
+      var fieldTypes = meta.field_types
       json.forEach(function (feature, i) {
         var lat, lon
         geojsonFeature = { type: 'Feature', geometry: {}, id: i + 1 }
@@ -457,6 +463,16 @@ var Socrata = function (koop) {
               }
               delete geojson.features[i].properties[f]
             }
+          }
+
+          // ensure all fields present, if undefined set to null
+          if(geojson.features[i].properties[f] === undefined) {
+            geojson.features[i].properties[f] = null
+          }
+
+          // type casting for numbers
+          if(fieldTypes[j] === "number" && geojson.features[i].properties[f] !== null) {
+            geojson.features[i].properties[f] = parseFloat(geojson.features[i].properties[f])
           }
         })
       })
@@ -548,6 +564,12 @@ var Socrata = function (koop) {
       }
       if (newInfo.errors) {
         info.errors = newInfo.errors
+      }
+      if (newInfo.field_types) {
+        info.field_types = newInfo.field_types
+      }
+      if (newInfo.field_types) {
+        info.fields = newInfo.fields
       }
       koop.Cache.updateInfo(table, info, function (err, success) {
         if (err) {

--- a/models/Socrata.js
+++ b/models/Socrata.js
@@ -453,7 +453,7 @@ var Socrata = function (koop) {
         }
 
         // make sure each feature has flattened object props
-        fields.forEach(function (f) {
+        fields.forEach(function (f, j) {
           if (f.substring(0, 1) !== ':') {
             if (typeof geojson.features[i].properties[f] === 'object') {
               for (var v in geojson.features[i].properties[f]) {
@@ -466,12 +466,12 @@ var Socrata = function (koop) {
           }
 
           // ensure all fields present, if undefined set to null
-          if(geojson.features[i].properties[f] === undefined) {
+          if (geojson.features[i].properties[f] === undefined) {
             geojson.features[i].properties[f] = null
           }
 
           // type casting for numbers
-          if(fieldTypes[j] === "number" && geojson.features[i].properties[f] !== null) {
+          if (fieldTypes[j] === 'number' && geojson.features[i].properties[f] !== null) {
             geojson.features[i].properties[f] = parseFloat(geojson.features[i].properties[f])
           }
         })

--- a/test/model.js
+++ b/test/model.js
@@ -134,11 +134,13 @@ test('getting a full page', function (t) {
 test('parsing geojson', function (t) {
   t.plan(5)
 
-  socrata.toGeojson([], 'location', [], function (err, geojson) {
+  var meta = {location_field: 'location', fields: [], field_types: []}
+
+  socrata.toGeojson([], meta, function (err, geojson) {
     t.deepEqual(err, 'Error converting data to GeoJSON: JSON not returned from Socrata or blank JSON returned')
   })
 
-  socrata.toGeojson(data, 'location', [], function (err, geojson) {
+  socrata.toGeojson(data, meta, function (err, geojson) {
     if (err) throw err
     t.deepEqual(geojson.features.length, 1000)
   })
@@ -157,10 +159,13 @@ test('parsing geojson', function (t) {
       longitude: 0
     }
   }]
-  socrata.toGeojson(features, 'location', ['obj'], function (err, geojson) {
+
+  meta.fields = ['obj']
+
+  socrata.toGeojson(features, meta, function (err, geojson) {
     if (err) throw err
-    t.deepEqual(geojson.features[0].properties, {obj_prop: true})
-    t.deepEqual(geojson.features[1].properties, {obj_prop: null})
+    t.deepEqual(geojson.features[0].properties, {obj: null, obj_prop: true})
+    t.deepEqual(geojson.features[1].properties, {obj: null, obj_prop: null})
     t.deepEqual(geojson.features.length, 2)
   })
 })
@@ -170,7 +175,8 @@ test('piping data through the process stream', function (t) {
   sinon.stub(socrata, 'getPage', function (url) {
     return fs.createReadStream(__dirname + '/fixtures/crimes::page.json')
   })
-  sinon.stub(socrata, 'toGeojson', function (json, locField, fields, callback) {
+
+  sinon.stub(socrata, 'toGeojson', function (json, meta, callback) {
     callback(null, { type: 'FeatureCollection', features: [{}] })
   })
   var meta = {}


### PR DESCRIPTION
@jgravois 

Test it out!

If the first record found has fields that are null, socrata doesn’t
return the field, so it is missing in the feature service json.  This
fix ensures all fields are there.  It also return numeric fields as
numbers instead of strings.  We are also storing the fields and socrata
field types for better date handling in the future.